### PR TITLE
Adjusted formatting to profile images

### DIFF
--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -93,16 +93,25 @@
   border-radius: 6px;
 }
 
+.profile-image {
+  max-width: 400px !important;
+  max-height: 225px !important;
+}
+
+.image-gap {
+  margin-right: 2rem;
+}
+
 .overlay {
   vertical-align: middle;
-  background-color: rgba(0, 0, 0, 0.2);
+  background-color: rgba(0, 0, 0, 0.4);
 }
 
 .overlay-text {
   font-weight: bold !important;
-  font-size: 4rem !important;
-  color: white;
-  padding-top: 20%;
+  font-size: 3.5rem !important;
+  color: rgba(255, 255, 255, 0.9);
+  padding-top: 15%;
   /* vertical-align: middle !important; */
 }
 

--- a/src/Components/Profile/profile.js
+++ b/src/Components/Profile/profile.js
@@ -45,39 +45,51 @@ const Profile = props => {
 
           <div className="tile is-parent is-vertical">
             <div className="tile is-parent">
-              <div className="tile card is-4">
-                <div className="card-image">
-                  <figure className="image">
-                    <img src="/img/userpage/roster.jpg" alt="Roster" />
-                  </figure>
-                  <div className="is-overlay overlay">
-                    <h1 className="overlay-text">ROSTER</h1>
-                  </div>
+              <div className="card-image image-gap">
+                <figure className="image profile-image">
+                  <img
+                    src="/img/userpage/roster.jpg"
+                    alt="Roster"
+                    className="profile-image"
+                  />
+                </figure>
+                <div className="is-overlay overlay">
+                  <h1 className="overlay-text">ROSTER</h1>
                 </div>
               </div>
-              <div className="tile card is-4">
-                <div className="card-image">
-                  <figure className="image">
-                    <img src="/img/userpage/depthchart1.jpg" alt="Roster" />
-                  </figure>
-                  <div className="is-overlay overlay">
-                    <h1 className="overlay-text">DEPTH CHART</h1>
-                  </div>
+              <div className="card-image image-gap">
+                <figure className="image profile-image">
+                  <img
+                    src="/img/userpage/depthchart1.jpg"
+                    alt="Roster"
+                    className="profile-image"
+                  />
+                </figure>
+                <div className="is-overlay overlay">
+                  <h1 className="overlay-text">DEPTH CHART</h1>
                 </div>
               </div>
             </div>
             <div className="tile is-parent">
-              <div className="card-image">
-                <figure className="image">
-                  <img src="/img/userpage/recruits3.png" alt="Roster" />
+              <div className="card-image image-gap">
+                <figure className="image profile-image">
+                  <img
+                    src="/img/userpage/recruits3.png"
+                    alt="Roster"
+                    className="profile-image"
+                  />
                 </figure>
                 <div className="is-overlay overlay">
                   <h1 className="overlay-text">RECRUITING</h1>
                 </div>
               </div>
-              <div className="card-image">
-                <figure className="image">
-                  <img src="/img/userpage/schedule.jpg" alt="Roster" />
+              <div className="card-image image-gap">
+                <figure className="image profile-image">
+                  <img
+                    src="/img/userpage/schedule.jpg"
+                    alt="Roster"
+                    className="profile-image"
+                  />
                 </figure>
                 <div className="is-overlay overlay">
                   <h1 className="overlay-text">SCHEDULING</h1>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8888347/64784717-57d16d00-d530-11e9-8eae-6456b1a6f1f6.png)

- Adjusted format for tile images so that all images have the same height and width.

To-Do:
- Add additional styling to images to make them pop out on the page. Considering using shadows and border-radius