### PR TITLE
Fixed image and overlay on team & profile pages

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import Profile from "./Components/Profile/Profile";
 import Roster from "./Components/Roster/Roster";
 import Team from "./Components/Team/Team";
 import "./style.css";
+import DepthChart from "./Components/DepthChart/DepthChart";
 
 class App extends Component {
   state = {
@@ -42,7 +43,11 @@ class App extends Component {
             path={routes.ROSTER}
             render={() => <Roster data={this.state.user} />}
           />
-          <Route exact path={routes.DEPTHCHART} component={LandingPage} />
+          <Route
+            exact
+            path={routes.DEPTHCHART}
+            render={() => <DepthChart data={this.state.user} />}
+          />
           <Route
             exact
             path={routes.AVAILABLE_TEAMS}

--- a/src/Components/DepthChart/DC_DropDown.js
+++ b/src/Components/DepthChart/DC_DropDown.js
@@ -1,0 +1,53 @@
+import React, { Component } from "react";
+import DropdownItem from "../Roster/DropdownItem";
+
+const DC_Dropdown = props => {
+  const [item, setItem] = React.useState("");
+  const dropdownAlignment = "dropdown is-" + props.align;
+  const id = "#" + props.id;
+  const activeDropdown = event => {
+    const dropdown = document.querySelector(id);
+    dropdown.classList.toggle("is-active");
+  };
+  const selectItem = event => {
+    setItem(event.target.value);
+    activeDropdown();
+  };
+
+  let type, mainLabel;
+  // If Dropdown is for teams
+  if (props.team) {
+    type = props.team;
+    mainLabel = props.data.team + " " + props.data.mascot;
+  } else {
+    // Dropdown is for position
+    type = props.position;
+    mainLabel = "Quarterback";
+  }
+
+  return (
+    <div className={dropdownAlignment} id={props.id}>
+      <div className="dropdown-trigger">
+        <button
+          className="button"
+          aria-haspopup="true"
+          aria-controls="dropdown-menu6"
+          onClick={activeDropdown}
+        >
+          <span>{type}</span>
+          <span className="icon is-small">
+            <i className="fas fa-angle-down" aria-hidden="true"></i>
+          </span>
+        </button>
+      </div>
+      <div className="dropdown-menu" id="dropdown-menu" role="menu">
+        <div className="dropdown-content">
+          <DropdownItem team={mainLabel} click={selectItem} />
+          <hr className="dropdown-divider"></hr>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DC_Dropdown;

--- a/src/Components/DepthChart/DepthChart.js
+++ b/src/Components/DepthChart/DepthChart.js
@@ -1,0 +1,170 @@
+import React, { useEffect } from "react";
+import SampleContent from "../Roster/SampleContent";
+import DropdownItem from "../Roster/DropdownItem";
+import DepthChartRow from "./DepthChartRow";
+import DC_Dropdown from "./DC_DropDown";
+
+const DepthChart = props => {
+  const [team, setTeam] = React.useState(
+    props.data.team + " " + props.data.mascot
+  );
+  const [roster, setRoster] = React.useState([]);
+
+  // DropDown
+  const activeDropdown = event => {
+    const dropdown = document.querySelector(".dropdown");
+    dropdown.classList.toggle("is-active");
+  };
+
+  const selectTeam = event => {
+    setTeam(event.target.value);
+    activeDropdown();
+  };
+
+  useEffect(() => {
+    let playerList = SampleContent.filter(player => player.team === team);
+    setRoster(playerList);
+  }, [team]);
+
+  // Rows
+  const PlayerRows = roster.map(player => (
+    <DepthChartRow key={player.id} data={player} />
+  ));
+  const playerCount = roster.length;
+  return (
+    <div className="hero-body center">
+      <div className="container is-fluid has-text-centered userInterface">
+        <h2 className="title is-3">Depth Chart</h2>
+        <div className="columns center is-12"></div>
+        <div className="columns is-left is-12">
+          <div className="column is-2">
+            <DC_Dropdown
+              team={team}
+              data={props.data}
+              align="left"
+              id="team-dropdown"
+            />
+          </div>
+          <div className="column is-8" />
+          <div className="column is-2">
+            <DC_Dropdown
+              position="Position"
+              data={props.data}
+              align="right"
+              id="position-dropdown"
+            />
+            {/* <div className="dropdown is-right">
+              <div className="dropdown-trigger">
+                <button
+                  name="position"
+                  className="button"
+                  aria-haspopup="true"
+                  aria-controls="dropdown-menu6"
+                  onClick={activeDropdown}
+                >
+                  <span>Position</span>
+                  <span className="icon is-small">
+                    <i className="fas fa-angle-down" aria-hidden="true"></i>
+                  </span>
+                </button>
+              </div>
+              <div className="dropdown-menu" id="dropdown-menu" role="menu">
+                <div className="dropdown-content">
+                  <DropdownItem
+                    team={props.data.team + " " + props.data.mascot}
+                    click={selectTeam}
+                  />
+                  <hr className="dropdown-divider"></hr>
+                </div>
+              </div>
+            </div> */}
+          </div>
+        </div>
+        <div className="is-divider" />
+        <div className="scrollbar roster-scrollbar">
+          <div className="table-wrapper">
+            <table className="table is-fullwidth is-hoverable">
+              <thead>
+                <tr>
+                  <th>
+                    <abbr title="Position">Pos</abbr>
+                  </th>
+                  <th>
+                    <abbr title="Archtype">Archtype</abbr>
+                  </th>
+                  <th>
+                    <abbr>Name</abbr>
+                  </th>
+                  <th>
+                    <abbr title="Overall">Ovr</abbr>
+                  </th>
+                  <th>
+                    <abbr title="Year">Yr</abbr>
+                  </th>
+                  <th>
+                    <abbr title="Height">Ht</abbr>
+                  </th>
+                  <th>
+                    <abbr title="Weight">Wt</abbr>
+                  </th>
+                  <th>
+                    <abbr title="State">St</abbr>
+                  </th>
+                  <th>
+                    <abbr title="High School / JUCO">School</abbr>
+                  </th>
+                  <th>
+                    <abbr title="Potential">Pot</abbr>
+                  </th>
+                  <th>
+                    <abbr title="Jersey Number">Num</abbr>
+                  </th>
+                </tr>
+              </thead>
+              <tfoot>
+                <tr>
+                  <th>
+                    <abbr title="Position">Pos</abbr>
+                  </th>
+                  <th>
+                    <abbr title="Archtype">Archtype</abbr>
+                  </th>{" "}
+                  <th>
+                    <abbr>Name</abbr>
+                  </th>
+                  <th>
+                    <abbr title="Overall">Ovr</abbr>
+                  </th>
+                  <th>
+                    <abbr title="Year">Yr</abbr>
+                  </th>
+                  <th>
+                    <abbr title="Height">Ht</abbr>
+                  </th>
+                  <th>
+                    <abbr title="Weight">Wt</abbr>
+                  </th>
+                  <th>
+                    <abbr title="State">St</abbr>
+                  </th>
+                  <th>
+                    <abbr title="High School / JUCO">School</abbr>
+                  </th>
+                  <th>
+                    <abbr title="Potential">Pot</abbr>
+                  </th>
+                  <th>
+                    <abbr title="Jersey Number">Num</abbr>
+                  </th>
+                </tr>
+              </tfoot>
+              <tbody>{PlayerRows}</tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DepthChart;

--- a/src/Components/DepthChart/DepthChartRow.js
+++ b/src/Components/DepthChart/DepthChartRow.js
@@ -1,0 +1,33 @@
+import React from "react";
+
+const DepthChartRow = props => {
+  /* 
+    Name, Position, Archtype, Ovr, Yr, Ht, Wt, St,
+    HS/JC, Pot, Num
+    
+    */
+  let data = props.data;
+  const toggleModal = () => {
+    props.toggle();
+    props.getData(data);
+  };
+  return (
+    <tr>
+      <td>{props.data.position}</td>
+      <td>{props.data.archtype}</td>{" "}
+      <th className="clickable" onClick={toggleModal}>
+        {props.data.name}
+      </th>
+      <td>{props.data.overall}</td>
+      <td>{props.data.year}</td>
+      <td>{props.data.height}</td>
+      <td>{props.data.weight}</td>
+      <td>{props.data.state}</td>
+      <td>{props.data.school}</td>
+      <td>{props.data.potential}</td>
+      <td>{props.data.jersey}</td>
+    </tr>
+  );
+};
+
+export default DepthChartRow;

--- a/src/Components/Profile/profile.js
+++ b/src/Components/Profile/profile.js
@@ -59,7 +59,7 @@ const Profile = props => {
               </div>
             </div>
 
-            <div className="tile is-parent is-vertical">
+            <div className="tile is-parent is-vertical images">
               <div className="tile is-parent">
                 <ImageCard
                   image="./img/userpage/roster4.jpg"

--- a/src/Components/Team/Team.js
+++ b/src/Components/Team/Team.js
@@ -56,7 +56,7 @@ const Team = props => {
               </p>
             </div>
           </div>
-          <div className="column is-7">
+          <div className="column is-7 is-vertical">
             <div className="tile is-parent">
               <ImageCard
                 image="./img/userpage/roster4.jpg"

--- a/src/style.css
+++ b/src/style.css
@@ -118,9 +118,13 @@
 /* End of team card on Available Teams Page */
 
 /* For Image Icons on User Profile Page */
+.images {
+  /* max-height: 100vh !important; */
+}
+
 .tile-image {
-  max-width: 385px !important;
-  max-height: 210px !important;
+  max-width: 40vh !important;
+  max-height: 40vh !important;
 }
 
 .image-gap {
@@ -133,7 +137,7 @@
   color: rgba(255, 255, 255, 0.9);
   transition: all 0.4s ease;
   -webkit-transition: all 0.4s ease;
-  height: 222px;
+  height: 100%;
 }
 
 .is-overlay.overlay:hover {
@@ -158,7 +162,7 @@
 }
 
 .roster-scrollbar {
-  max-height: 50vh !important;
+  max-height: 49vh !important;
 }
 
 .roster-item {


### PR DESCRIPTION
Fixed overlay clipping due to sizing differences between images on the team and roster page
![image](https://user-images.githubusercontent.com/8888347/67905406-3b6cac80-fb3f-11e9-949f-d487b695d933.png)
User Profile page

![image](https://user-images.githubusercontent.com/8888347/67905421-49223200-fb3f-11e9-9d51-6ab0081559e1.png)
Team Page

Note: When implementing backend and doing testing for multiple teams, we will likely need to look into this issue in the future.